### PR TITLE
dotb-fmt scripts

### DIFF
--- a/dotb-fmt/README.md
+++ b/dotb-fmt/README.md
@@ -1,0 +1,18 @@
+# dotb-fmt
+Supplementary tools for FM-Towns Dead of the Brain
+
+These two scripts can be used to extract as well as recreate the archived files used on the FM-Towns release. Once extracted the files are the same as PC-98 and should be able to have the translation patch applied. Two scripts are included. fmt-builder.py and fmt-extractor.py
+
+# fmt-extractor.py
+
+Simply call a file with the script to have it extracted to a folder named "<FILENAME> output" along with an order list inside the folder named "filelist". You can also drag & drop a file to have it extract.
+
+> fmt-extractor.py BRAIN.003
+
+# fmt-builder.py
+
+Simply call the script with a directory to have it recreated as the original file. The script will read the filelist to mash up all the files and recreate the header. You can also drag & drop folders to have them rebuilt.
+
+> fmt-builder.py "BRAIN.003 output"
+
+Please note that these were made with Windows in mind and probably won't work on other operating systems.

--- a/dotb-fmt/fmt-builder.py
+++ b/dotb-fmt/fmt-builder.py
@@ -1,0 +1,73 @@
+import os, sys, binascii
+from shutil import copyfileobj
+
+path=sys.argv[1]
+parentfile=open(path.strip(" output"),"wb+")
+filename = [filename.rstrip('\n') for filename in open(sys.argv[1]+"\\fileorder", "r")]
+startloc = [0] * (len(filename))
+endloc = []
+count = 0
+count2 = 0
+data = ""
+header = ""
+location = [""] * 8
+
+# Create initial header
+while count < len(filename):
+    headerlist = ["\x00"] * 16
+    currentfile = list(filename[count])
+    while count2 < len(currentfile):
+        headerlist[count2] = currentfile[count2]
+        count2 += 1
+    header = "".join(headerlist)
+    data += header
+    del headerlist[:]
+    count2 = 0
+    count += 1
+count = 0
+data += "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+parentfile.write(bytes(data, 'ascii'))
+startloc[0]=hex(len(data))
+
+#Slap data on to file
+while count < len(filename):
+    print("Doing",path+"\\"+filename[count])
+    tmpfile=open(path+"\\"+filename[count],"rb")
+    copyfileobj(tmpfile,parentfile)
+    parentfile.seek(0, os.SEEK_END)
+    if count+1 < len(filename):
+        startloc[count+1] = hex(parentfile.tell())
+    else:
+        endloc = hex(parentfile.tell())
+    count += 1
+count=0
+
+
+#Go back and put the locations in the header
+parentfile.seek(0)
+while count < len(filename):
+    parentfile.seek(12,1)
+    startloclist=list(startloc[count])
+    if (len(startloclist)) == 4:
+        location = [startloclist[2],startloclist[3],"0","0","0","0","0","0"]
+    if (len(startloclist)) == 5:
+        location = [startloclist[3],startloclist[4],"0",startloclist[2],"0","0","0","0"]
+    if (len(startloclist)) == 6:
+        location = [startloclist[4],startloclist[5],startloclist[2],startloclist[3],"0","0","0","0"]
+    if (len(startloclist)) == 7:
+        location = [startloclist[5],startloclist[6],startloclist[3],startloclist[4],"0",startloclist[2],"0","0"]
+    locationst="".join(location)
+    parentfile.write(binascii.unhexlify(locationst))
+    count += 1
+parentfile.seek(12,1)
+startloclist=list(endloc)
+location = [startloclist[5],startloclist[6],startloclist[3],startloclist[4],"0",startloclist[2],"0","0"]
+locationst="".join(location)
+parentfile.write(binascii.unhexlify(locationst))
+parentfile.close()
+    
+
+    
+
+print("We wrote",filename,"to",parentfile,"and these locations",startloc,"ending at",endloc)
+parentfile.close()

--- a/dotb-fmt/fmt-extractor.py
+++ b/dotb-fmt/fmt-extractor.py
@@ -1,0 +1,63 @@
+import os, sys
+
+file = open(sys.argv[1], 'rb+')
+filename = []
+startloc = []
+endloc = []
+finished = False
+count = 0
+path = sys.argv[1] + " output"
+
+def oddswap(st):
+    s = list(st)
+    t = [s[6], s[7], s[4], s[5], s[2], s[3], s[0], s[1]]
+    s = "".join(t)
+    return s
+
+def readline():
+    return file.read(16)
+
+# grab the file information from the header stop when null hit
+for line in iter(readline, ''):
+    if not finished:
+        if line[:10] != b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00":
+            filename.append(line[:12].decode().rstrip('\x00'))
+            startloc.append(oddswap(line[-4:].hex()))
+        else:
+            endloctemp =line[-4:].hex()
+            endloc = oddswap(line[-4:].hex())
+            finished = True
+            break
+print("The files are ",filename," files at ",startloc," and ends at ",endloc)
+
+try:
+    os.mkdir(path)
+except OSError:
+    print ("Creation of the directory %s failed" % path)
+else:
+    print ("Successfully created the directory %s " % path)
+
+# store the chunks of data as their files
+while count < len(filename):
+    file.seek(int("0x" + startloc[count], 16))
+    if count+1 < len(filename):
+        temploc = int("0x" + startloc[count+1], 16)
+        temploc = temploc - int("0x" + startloc[count], 16)
+        readfile = file.read(temploc)
+    else:
+        temploc = int("0x" + endloc, 16) - int("0x" + startloc[count], 16)
+        readfile = file.read(temploc)
+    destination = path + "\\" + filename[count]
+    read = open(destination, "wb")
+    read.write(readfile)
+    read.close
+    print("Wrote",filename[count], "with the file size",temploc, "bytes")
+    count += 1
+
+# store the order of files for archiving in a file named fileorder
+destination = path + "\\fileorder"
+with open(destination, "w") as read:
+    for item in filename:
+        read.write("%s\n" % item)
+read.close
+file.close


### PR DESCRIPTION
Set of scripts to interact with DotB archives on FM-Towns. This will allow the PC-98 tools to work on FM-Towns files as well.